### PR TITLE
Add support for $_SERVER['REQUEST_SCHEME']

### DIFF
--- a/frontend/class-prevent-xss-vulnerability-frontend.php
+++ b/frontend/class-prevent-xss-vulnerability-frontend.php
@@ -142,12 +142,15 @@ class Prevent_XSS_Vulnerability_Frontend {
     // If the Original Page URI and the URI after XSS Detection does not same
     // then, redirect the user on the URI which doesn't contain XSS Parameters
     if ( $get_page_uri != $xss_detection ) {
+      $protocol = isset($_SERVER['REQUEST_SCHEME']) ? $_SERVER['REQUEST_SCHEME'] : 'http';
+
       if ( isset( $_SERVER['HTTP_USER_AGENT_HTTPS'] )
         && 'ON' == $_SERVER['HTTP_USER_AGENT_HTTPS'] ) {
-        $xss_detection = 'https://' . $_SERVER['HTTP_HOST'] . $xss_detection;
-      } else {
-        $xss_detection = 'http://' . $_SERVER['HTTP_HOST'] . $xss_detection;
+        $protocol = 'https';
       }
+
+      $xss_detection = $protocol . '://' . $_SERVER['HTTP_HOST'] . $xss_detection;
+
       header( 'HTTP/1.0 301 Moved Permanently' );
       header( 'Location: ' . $xss_detection );
       exit();


### PR DESCRIPTION
### Description
We host our WordPress on [Pantheon](https://pantheon.io/) and we do not have `$_SERVER['HTTP_USER_AGENT_HTTPS']` available. This causes the `$xss_detection` URL to be created with the wrong protocol, `http`.

This PR:
* Adds support for `$_SERVER['REQUEST_SCHEME']` when creating the full `$xss_detection` URL
* Maintains support for `$_SERVER['HTTP_USER_AGENT_HTTPS']`
